### PR TITLE
Store RFC3339 timestamp in the UTC timezone

### DIFF
--- a/mozlog.go
+++ b/mozlog.go
@@ -71,7 +71,7 @@ func NewAppLog(loggerName string, msg []byte) *AppLog {
 	now := time.Now().UTC()
 	return &AppLog{
 		Timestamp:  now.UnixNano(),
-		Time:       now.Format(time.RFC3339Nano),
+		Time:       now.Format(time.RFC3339),
 		Type:       "app.log",
 		Logger:     loggerName,
 		Hostname:   hostname,

--- a/mozlog.go
+++ b/mozlog.go
@@ -56,6 +56,7 @@ func (m *MozLogger) Write(l []byte) (int, error) {
 // AppLog implements Mozilla logging standard
 type AppLog struct {
 	Timestamp  int64
+	Time       string
 	Type       string
 	Logger     string
 	Hostname   string `json:",omitempty"`
@@ -67,8 +68,10 @@ type AppLog struct {
 
 // NewAppLog returns a loggable struct
 func NewAppLog(loggerName string, msg []byte) *AppLog {
+	now := time.Now().UTC()
 	return &AppLog{
-		Timestamp:  time.Now().UnixNano(),
+		Timestamp:  now.UnixNano(),
+		Time:       now.Format(time.RFC3339Nano),
 		Type:       "app.log",
 		Logger:     loggerName,
 		Hostname:   hostname,


### PR DESCRIPTION
The `mozlog` standard allows for a `Time` fields contains the human readable RFC3339 timestamp. I thought this would be a worthwhile addition to the default log format.

I also think we should enforce logging in the UTC timezone to avoid timezone convertion of the timestamp (which doesn't currently contain timezone information). I'm concerned this might break things, so definitely needs review by @oremj and @mostlygeek.