### PR TITLE
Fields support, fixes #6

### DIFF
--- a/mozlog.go
+++ b/mozlog.go
@@ -68,6 +68,20 @@ type AppLog struct {
 
 // NewAppLog returns a loggable struct
 func NewAppLog(loggerName string, msg []byte) *AppLog {
+	var (
+		err    error
+		isJson = false
+		fields = make(map[string]interface{})
+	)
+	if len(msg) > 1 && msg[0] == '{' {
+		isJson = true
+		err = json.Unmarshal(msg, &fields)
+	}
+	// if the msg is not json or unmarshalling it failed,
+	// store it as a string under the `msg` field
+	if !isJson || err != nil {
+		fields["msg"] = string(bytes.TrimSpace(msg))
+	}
 	now := time.Now().UTC()
 	return &AppLog{
 		Timestamp:  now.UnixNano(),
@@ -77,9 +91,7 @@ func NewAppLog(loggerName string, msg []byte) *AppLog {
 		Hostname:   hostname,
 		EnvVersion: "2.0",
 		Pid:        os.Getpid(),
-		Fields: map[string]interface{}{
-			"msg": string(bytes.TrimSpace(msg)),
-		},
+		Fields:     fields,
 	}
 }
 

--- a/mozlog.go
+++ b/mozlog.go
@@ -71,7 +71,7 @@ func NewAppLog(loggerName string, msg []byte) *AppLog {
 	now := time.Now().UTC()
 	return &AppLog{
 		Timestamp:  now.UnixNano(),
-		Time:       now.Format(time.RFC3339Nano),
+		Time:       now.Format(time.RFC3339),
 		Type:       "app.log",
 		Logger:     loggerName,
 		Hostname:   hostname,

--- a/mozlog.go
+++ b/mozlog.go
@@ -56,6 +56,7 @@ func (m *MozLogger) Write(l []byte) (int, error) {
 // AppLog implements Mozilla logging standard
 type AppLog struct {
 	Timestamp  int64
+	Time       string
 	Type       string
 	Logger     string
 	Hostname   string `json:",omitempty"`
@@ -67,8 +68,10 @@ type AppLog struct {
 
 // NewAppLog returns a loggable struct
 func NewAppLog(loggerName string, msg []byte) *AppLog {
+	now := time.Now().UTC()
 	return &AppLog{
-		Timestamp:  time.Now().UnixNano(),
+		Timestamp:  now.UnixNano(),
+		Time:       now.Format(time.RFC3339Nano),
 		Type:       "app.log",
 		Logger:     loggerName,
 		Hostname:   hostname,

--- a/mozlog_test.go
+++ b/mozlog_test.go
@@ -23,3 +23,19 @@ func TestMozLogger(t *testing.T) {
 
 	assert.Equal(t, "test message", logEntry.Fields["msg"])
 }
+
+func TestJSONLogger(t *testing.T) {
+	log.SetFlags(0)
+
+	in := new(bytes.Buffer)
+	Logger.Output = in
+
+	log.Println(`{"a": 1234, "b": true, "c": [1, 2]}`)
+
+	var logEntry AppLog
+	err := json.Unmarshal(in.Bytes(), &logEntry)
+	assert.NoError(t, err)
+	lefields, err := json.Marshal(logEntry.Fields)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"b": true, "c": [1, 2], "a": 1234}`, string(lefields))
+}


### PR DESCRIPTION
This implements setting various fields by logging an `[]byte` that's actually a json string. It doesn't break backward compatibility, and the json test should be fast enough since we only look for `msg[0] == '{'`.

Blocked by #5